### PR TITLE
Added dynamic page titles

### DIFF
--- a/views/facts/edit.ejs
+++ b/views/facts/edit.ejs
@@ -1,5 +1,7 @@
 <% include ../partials/header %>
 
+<title>Edit Fact | Fight For The Climate</title>
+
 <div class="container">
     <div id="page-form">
         <h3>Add new fact</h3>

--- a/views/facts/new.ejs
+++ b/views/facts/new.ejs
@@ -1,5 +1,7 @@
 <% include ../partials/header %>
 
+<title>New Fact | Fight For The Climate</title>
+
 <div class="container">
     <div id="page-form">
         <h3>Add new fact</h3>

--- a/views/facts/show.ejs
+++ b/views/facts/show.ejs
@@ -1,5 +1,7 @@
 <% include ../partials/header %>
 
+<title><%= fact.headline %></title>
+
 <div class="container my-5">
     <div id="fact-show">
         <div class="flex top">

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -1,5 +1,7 @@
 <% include ./partials/header %>
 
+<title>Home | Fight For The Climate</title>
+
 <!-- FACTS -->
 <div class="container">
     <h4 class="mt-5">Facts</h4>

--- a/views/sources/edit.ejs
+++ b/views/sources/edit.ejs
@@ -1,1 +1,3 @@
+<title>Edit Source | Fight For The Climate</title>
+
 <h1>edit page!</h1>

--- a/views/sources/index.ejs
+++ b/views/sources/index.ejs
@@ -1,5 +1,7 @@
 <% include ../partials/header %>
 
+<title>Sources | Fight For The Climate</title>
+
 <div class="container mt-3">
     <h1>Sources</h1>
     

--- a/views/sources/new.ejs
+++ b/views/sources/new.ejs
@@ -1,5 +1,7 @@
 <% include ../partials/header %>
 
+<title>New Source | Fight For The Climate</title>
+
 <div class="container">
     <div id="page-form">
         <h3>Add a new source</h3>

--- a/views/sources/show.ejs
+++ b/views/sources/show.ejs
@@ -1,5 +1,7 @@
 <% include ../partials/header %>
 
+<title><%= source.name_long %></title>
+
 <div class="container my-5">
     <div class="flex">
         <a href="/sources" class="prev-page"><i class="far fa-arrow-alt-circle-left"></i> Source List</a>


### PR DESCRIPTION
All pages now have titles. Certain dynamic pages (like `facts/show.ejs`
and `sources/show.ejs`) have dynamic titles, based on the headline or
source name.

I was unable to test the code as I could not connect to the MongoDB database, which is necessary for testing.
I am confident, however, that my changes were so simple they should work fine.

Let me know if there are any titles you'd prefer different, as I stuck to generic ones.

Should close #5 